### PR TITLE
Use latest version of SnakeYAML

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.yaml/snakeyaml "1.17"]
+                 [org.yaml/snakeyaml "1.18"]
                  [org.flatland/ordered "1.5.2"]])

--- a/test/yaml/reader_test.clj
+++ b/test/yaml/reader_test.clj
@@ -56,6 +56,10 @@ the-bin: !!binary 0101")
 ? Sammy Sosa
 ? Ken Griff")
 
+(def emojis-yaml
+  ;; Unicode SMILING FACE WITH OPEN MOUTH AND SMILING EYES
+  (apply str (Character/toChars 128516)))
+
 (deftest parse-multiple-documents
   (testing "should handle multiple yaml documents"
     (is (= ["foo" "bar"]
@@ -119,3 +123,6 @@ the-bin: !!binary 0101")
   (binding [*keywordize* false]
     (is  (= "items" (-> hashes-lists-yaml parse-string ffirst))))
     (is  (= "items" (-> hashes-lists-yaml (parse-string false) ffirst))))
+
+(deftest emojis
+  (is (pos? (count (parse-string emojis-yaml)))))


### PR DESCRIPTION
Version 1.18 fixes a number of issues (see https://bitbucket.org/asomov/snakeyaml/wiki/Changes), including a problem with files that contain emojis.