### PR TITLE
Re-add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: clojure
+script: lein test


### PR DESCRIPTION
It looks like travis isn't able to infer the project type, so we should be explicit by re-adding the travis file.