### PR TITLE
Allow unknown YAML tags to be represented as the underlying datatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ An updated YAML library for Clojure based on Snake YAML and heavily inspired by 
 (yaml/parse-string "foo: bar")
 
 ;; Optionally pass `true` as a second argument to from-file or parse-string to keywordize all keys
-(yaml/parse-string "foo: bar" true)
+(yaml/parse-string "foo: bar" :keywords true)
+
+;; Parsing YAML with unknown tags
+(yaml/parse-string "--- !foobar
+  foo: HELLO WORLD")
+
+;; This will parse properly
+(yaml/parse-string "--- !foobar
+  foo: HELLO WORLD" :constructor yaml.reader/passthrough-constructor)
 
 ;; Dump YAML
 

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.yaml/snakeyaml "1.19"]
-                 [org.flatland/ordered "1.5.2"]])
+                 [org.flatland/ordered "1.5.2"]]
+  :java-source-paths ["src-java"])

--- a/src-java/org/yaml/snakeyaml/constructor/PassthroughConstructor.java
+++ b/src-java/org/yaml/snakeyaml/constructor/PassthroughConstructor.java
@@ -1,0 +1,39 @@
+package org.yaml.snakeyaml.constructor;
+
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.Tag;
+
+/**
+ * Implementation of Constructor that ignores YAML tags.
+ *
+ * This is used as a fallback strategies to use the underlying type instead of
+ * throwing an exception.
+ */
+public class PassthroughConstructor extends Constructor {
+
+    private class PassthroughConstruct extends AbstractConstruct {
+        public Object construct(Node node) {
+            // reset node to scalar tag type for parsing
+            Tag tag = null;
+            switch (node.getNodeId()) {
+            case scalar:
+                tag = Tag.STR;
+            case sequence:
+                tag = Tag.SEQ;
+            default:
+                tag = Tag.MAP;
+            }
+
+            node.setTag(tag);
+            return getConstructor(node).construct(node);
+        }
+
+        public void construct2ndStep(Node node, Object object) {}
+    }
+
+    public PassthroughConstructor() {
+        // Add a catch-all to catch any unidentifiable nodes
+        this.yamlMultiConstructors.put("", new PassthroughConstruct());
+    }
+}

--- a/src/yaml/core.clj
+++ b/src/yaml/core.clj
@@ -22,4 +22,4 @@
     (from-file f true))
   ([f keywords]
   (when-let [contents (safe-read f)]
-    (parse-string contents keywords))))
+    (parse-string contents :keywords keywords))))


### PR DESCRIPTION
In Clojure-land, we should allow unknown tags to be represented using the
underlying data type. This is preferrable to failing when working with unknown
YAML.

