### PR TITLE
Do not re-use constructors for parse-string

### DIFF
--- a/test/yaml/reader_test.clj
+++ b/test/yaml/reader_test.clj
@@ -148,3 +148,11 @@ the-bin: !!binary 0101")
     (is (= {:en "TEXT IN ENGLISH"
             :de "TEXT IN DEUTSCH"}
            (parse-string custom-tags-yaml :constructor passthrough-constructor)))))
+
+(deftest parse-string-thread-safety
+  (testing "should not throw any exceptions when parsing objects concurrently"
+    (let [results (doall (for [x (range 100)]
+                           (future (parse-string inline-list-yaml))))]
+      (doseq [result results]
+        ;; when non-threadsafe, Exceptions are thrown unexpectedly
+        (is (= ["milk" "pumpkin pie" "eggs" "juice"] @result))))))


### PR DESCRIPTION
According to the docs, the Yaml and by extension the constructor objects are not
thread-safe. These constructors should be created on-demand (by wrapping in a lambda).

See [docs](https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-threading)