### PR TITLE
Set javac options to emit Java 7 source code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,5 @@
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases true}]]
-  :java-source-paths ["src-java"])
+  :java-source-paths ["src-java"]
+  :javac-options ["-target" "1.7", "-source" "1.7"])


### PR DESCRIPTION
Fixes #37

Add Lein `:javac-options` so `javac` will emit Java 7 bytecode instead of the byte code version associated with the JDK you compiled it with.

(Java 7 seemed appropriate here since SnakeYAML itself is compiled with Java 7 bytecode, even if Java 7 is a little long in the tooth at this point.)

I built this locally with Java 16 and then tested with Java 8 and confirmed that it fixes the issue.